### PR TITLE
Make package python3.12 ready because imp is not exisiting anymore

### DIFF
--- a/extended_settings/apps.py
+++ b/extended_settings/apps.py
@@ -6,7 +6,7 @@
 
 import os
 import sys
-import imp
+import types
 import glob
 from django.apps import AppConfig
 from django.conf import settings
@@ -66,7 +66,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
             # module transformation
             module_name = file_settings.split(".py")[0]
-            module = imp.new_module(module_name)
+            module = types.ModuleType(module_name)
             module.__file__ = file_settings
             sys.modules[module_name] = module
 


### PR DESCRIPTION
I using your package and i really like it but with python 3.12 it don't work anymore. So for my this fixed it because imp was removed in python 3.12.

"Use python 3.11. imp is deprecated"

Because ubuntu 24.04 ships python 3.12 directly and i think also debain 12. So would be nice and easier for my case.